### PR TITLE
Add Error Propagation to Second Moment Correlation Lenght and Wall to Wall Correlation

### DIFF
--- a/src/Greens.py
+++ b/src/Greens.py
@@ -46,12 +46,18 @@ def second_moment_correletion_length(beta,N,SU,order,N_order,N_measure,N_thermal
     values, error = np.load(file_name)
     Gf = np.fft.fft2(values)
     p = 2*np.pi/N
+    error_s = np.sqrt(np.sum(error**2))
+    error_2 = np.sqrt(np.sum(np.array([ [(error * np.exp(1j*(p)*j))**2 for j in range(N)]for i in range(N)])))
     """Gf1 =np.sum(np.array([ [values[i,j] * np.exp(1j*(p)*j) for j in range(N)]for i in range(N)]))
     #print(np.sum(Gf1))
     Gf0 = np.sum(np.array([[values[i,j] for j in range(N)] for i in range(N)]))
     """
+    print(error_s,error_2)
     print(Gf[0,1]-Gf[0,1].real)
-    return (1/(4*np.sin(np.pi/N)*np.sin(np.pi/N))*(Gf[0,0]/Gf[0,1]-1))**0.5,Gf[0,0]
+    sq = (1/(4*np.sin(np.pi/N)*np.sin(np.pi/N))*(Gf[0,0]/Gf[0,1]-1))
+    error_sq = ((1/(4*np.sin(np.pi/N)*np.sin(np.pi/N))*(1/Gf[0,1])*error_s)**2+(1/(4*np.sin(np.pi/N)*np.sin(np.pi/N))*(Gf[0,0]/Gf[0,1]**2))**2*error_2**2)**0.5
+    error_f = np.sqrt((1/(2*sq**0.5)*error_sq)**2)
+    return (sq)**0.5,error_f
 
 def second_moment_correletion_length_three(beta,N,SU,order,N_order,N_measure,N_thermal):
     observable_name = 'Greens 2'

--- a/src/Greens.py
+++ b/src/Greens.py
@@ -5,12 +5,15 @@ def Greens_mom(beta,N,SU,order,N_order,N_measure,N_thermal):
     file_name = "ChiralResults/Processed/"+observable_name+"/"+observable_name+" beta = " + str(beta) + " N = " + str(N)  + " SU = " + str(SU)+" Order = "  + str(order)+" N Order = "  + str(N_order)+" N measurements = "  + str(N_measure)+" N Thermal = "  + str(N_thermal)+'.npy'
     values,errors  = np.load(file_name)
     Greens_zero_mom = np.zeros((N+1))
+    error_zero = np.zeros((N+1))
     for i in range(N):
         Greens_zero_mom[i] = np.sum(values[i])
+        error_zero[i] = np.sqrt(np.sum(errors[i]**2))
     Greens_zero_mom[N] = Greens_zero_mom[0]
+    error_zero[N] = error_zero[0]
     observable_name = 'Greens 0 Mom'
     file_name = "ChiralResults/Processed/"+observable_name+"/"+observable_name+" beta = " + str(beta) + " N = " + str(N)  + " SU = " + str(SU)+" Order = "  + str(order)+" N Order = "  + str(N_order)+" N measurements = "  + str(N_measure)+" N Thermal = "  + str(N_thermal)+'.npy'
-    np.save(file_name,Greens_zero_mom/Greens_zero_mom[0])
+    np.save(file_name,(Greens_zero_mom/Greens_zero_mom[0],error_zero/Greens_zero_mom[0]))
 def susceptibility_from_complete_greens_function(beta,N,SU,order,N_order,N_measure,N_thermal):
     observable_name = 'Greens 2'
     file_name = "ChiralResults/Processed"+observable_name+"/"+observable_name+" beta = " + str(beta) + " N = " + str(N)  + " SU = " + str(SU)+" Order = "  + str(order)+" N Order = "  + str(N_order)+" N measurements = "  + str(N_measure)+" N Thermal = "  + str(N_thermal)+'.npy'
@@ -47,6 +50,7 @@ def second_moment_correletion_length(beta,N,SU,order,N_order,N_measure,N_thermal
     #print(np.sum(Gf1))
     Gf0 = np.sum(np.array([[values[i,j] for j in range(N)] for i in range(N)]))
     """
+    print(Gf[0,1]-Gf[0,1].real)
     return (1/(4*np.sin(np.pi/N)*np.sin(np.pi/N))*(Gf[0,0]/Gf[0,1]-1))**0.5,Gf[0,0]
 
 def second_moment_correletion_length_three(beta,N,SU,order,N_order,N_measure,N_thermal):

--- a/src/plotting.py
+++ b/src/plotting.py
@@ -288,7 +288,7 @@ def weak_coupling(beta):
 def plot_Greens_0_mom(beta,N,SU,order,N_order,N_measure,N_thermal):
     observable_name = 'Greens 0 Mom'
     file_name = "ChiralResults/Processed/"+observable_name+"/"+observable_name+" beta = " + str(beta) + " N = " + str(N)  + " SU = " + str(SU)+" Order = "  + str(order)+" N Order = "  + str(N_order)+" N measurements = "  + str(N_measure)+" N Thermal = "  + str(N_thermal)+'.npy'
-    values = np.load(file_name)
+    values,errors = np.load(file_name)
     xdata = np.arange(N+1)
     def model(t, dE):
         L = N
@@ -298,7 +298,7 @@ def plot_Greens_0_mom(beta,N,SU,order,N_order,N_measure,N_thermal):
     
     print(a)
     ax = plt.subplot(111)
-    ax.plot(xdata,values,'.k')
+    ax.errorbar(xdata,values,yerr=errors,fmt='.k')
     ax.plot(xdata,ys)
     ax.spines[['right', 'top']].set_visible(False)
     plt.show()


### PR DESCRIPTION
I have added the code to obtain an estimate of the error for the Second Moment Correlation length and the Points of the Wall-Point Correlation. As these quantities are defined through $G(x) = \ranlge \frac 1 N Re Tr[U(x)U^\dagger (0)] \langle $ it is not possible to obtain the errors directly for the simulation as only the errors for the individual points of $G(x) = G(x_1,x_2)$ are accessible in this manner. Therefore I propagated the errors from the definition of each quantity from G(x). This should be a reasonable estimate of the errors but the variables might be correlated so I might want to revise this sometime later in the project (the errors might be underestimated)