### PR TITLE
Optimized Matrix multiplication

### DIFF
--- a/src/Chiral.py
+++ b/src/Chiral.py
@@ -127,7 +127,8 @@ class Chiral(object):
         
         exponential_matrix = Mat.exponential(epsilon * p, order, SU, order_N)
         
-        Unew = np.einsum('ijkl,ijlm->ijkm', exponential_matrix,U_0)
+        Unew = Mat.multiply_matrices(exponential_matrix, U_0)
+        #np.einsum('ijkl,ijlm->ijkm', exponential_matrix,U_0)
        
         for i in range(N_tau):
             
@@ -136,7 +137,8 @@ class Chiral(object):
             exponential_matrix = Mat.exponential(epsilon * p, order, SU, order_N)
             
             
-            Unew = np.einsum('ijkl,ijlm->ijkm', exponential_matrix, Unew)
+            Unew = Mat.multiply_matrices(exponential_matrix, Unew)
+            #np.einsum('ijkl,ijlm->ijkm', exponential_matrix, Unew)
         
         p += epsilon/2 * Chiral.dot_p(Unew, beta, SU, identity)
         

--- a/src/matrix_routines.py
+++ b/src/matrix_routines.py
@@ -17,7 +17,7 @@ def multiply_matrices(lattice_a, lattice_b):
     of all the elements (matrix_wise) of two lattices
     """
 
-    return np.einsum('ijkl,ijlm->ijkm', lattice_a, lattice_b)
+    return np.matmul(lattice_a, lattice_b)
 
 def exponential(lattice, order, su_parameter, order_n):
     """

--- a/src/test_matrix_routines.py
+++ b/src/test_matrix_routines.py
@@ -24,10 +24,10 @@ class TestMatrixRoutines(unittest.TestCase):
         np.testing.assert_array_equal(Mat.multiply_matrices(self.A, self.Identity), expected_output)
 
     def test_multiply_matrices_random_input(self):
-        B = np.random.uniform(size=(self.N, self.N, self.SU, self.SU))
+        B = np.random.uniform(size=(self.N, self.N, self.SU, self.SU))+1j*np.random.uniform(size = (self.N,self.N,self.SU,self.SU))
         # Compute the expected output using a known correct method
-        expected_output = np.matmul(self.A, B)
-        np.testing.assert_array_almost_equal(Mat.multiply_matrices(self.A, B), expected_output)
+        expected_output = np.einsum('ijkl,ijlm->ijkm',self.C, B)
+        np.testing.assert_array_almost_equal(Mat.multiply_matrices(self.C, B), expected_output)
     def test_matrix_multiplication_with_identity(self):
         self.assertTrue(np.all(self.A ==Mat.multiply_matrices(self.A,self.Identity) ))
         self.assertTrue(np.all(Mat.multiply_matrices(self.A,self.Identity) ==Mat.multiply_matrices(self.A,self.Identity) ))


### PR DESCRIPTION
Changed np.einsum() by np.matmul in al instances where it led to inefficiency